### PR TITLE
Update overlaps to ignore end date

### DIFF
--- a/app/assets/javascripts/hqmf_util.js.coffee
+++ b/app/assets/javascripts/hqmf_util.js.coffee
@@ -304,9 +304,9 @@ class IVL_TS
     if @high.date == null && other.high.date == null
       true # If neither have ends, they inherently overlap on the timeline
     else if @high.date == null
-      this.SBS(other)
+      !this.SAE(other)
     else if other.high.date == null
-      this.SBS(other) && this.EAS(other)
+      !this.EBS(other)
     else
       this.SDU(other) || this.EDU(other) || (this.SBS(other) && this.EAE(other))
   

--- a/app/assets/javascripts/hqmf_util.js.coffee
+++ b/app/assets/javascripts/hqmf_util.js.coffee
@@ -301,10 +301,14 @@ class IVL_TS
   
   # Overlap: this overlaps with other
   OVERLAP: (other) -> 
-    if @high.date && other.high.date
-      this.SDU(other) || this.EDU(other) || (this.SBS(other) && this.EAE(other))
+    if @high.date && other.high.date == null
+      true # If neither have ends, they inherently overlap on the timeline
+    else if @high.date == null
+      this.SBS(other)
+    else if other.high.date == null
+      this.SBS(other) && !this.EBS(other)
     else
-      this.SDU(other) || this.EDU(other) || this.SBS(other)
+      this.SDU(other) || this.EDU(other) || (this.SBS(other) && this.EAE(other))
   
   # Concurrent: this low and high are the same as other low and high
   CONCURRENT: (other) -> this.SCW(other) && this.ECW(other)

--- a/app/assets/javascripts/hqmf_util.js.coffee
+++ b/app/assets/javascripts/hqmf_util.js.coffee
@@ -300,7 +300,11 @@ class IVL_TS
   DURING: (other) -> this.SDU(other) && this.EDU(other)
   
   # Overlap: this overlaps with other
-  OVERLAP: (other) -> this.SDU(other) || this.EDU(other) || (this.SBS(other) && this.EAE(other))
+  OVERLAP: (other) -> 
+    if @high.date && other.high.date
+      this.SDU(other) || this.EDU(other) || (this.SBS(other) && this.EAE(other))
+    else
+      this.SDU(other) || this.EDU(other) || this.SBS(other)
   
   # Concurrent: this low and high are the same as other low and high
   CONCURRENT: (other) -> this.SCW(other) && this.ECW(other)

--- a/app/assets/javascripts/hqmf_util.js.coffee
+++ b/app/assets/javascripts/hqmf_util.js.coffee
@@ -301,12 +301,12 @@ class IVL_TS
   
   # Overlap: this overlaps with other
   OVERLAP: (other) -> 
-    if @high.date && other.high.date == null
+    if @high.date == null && other.high.date == null
       true # If neither have ends, they inherently overlap on the timeline
     else if @high.date == null
       this.SBS(other)
     else if other.high.date == null
-      this.SBS(other) && !this.EBS(other)
+      this.SBS(other) && this.EAS(other)
     else
       this.SDU(other) || this.EDU(other) || (this.SBS(other) && this.EAE(other))
   

--- a/test/unit/library_function_test.rb
+++ b/test/unit/library_function_test.rb
@@ -361,6 +361,9 @@ class LibraryFunctionTest < Test::Unit::TestCase
     @context.eval('var events1 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120105"), new TS("20120105"));}}]')
     @context.eval('var events2 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120102"), new TS("20120105"));}}]')
     @context.eval('var events3 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120105203030"), new TS("20120105203030"));}}]')
+    @context.eval('var nullEndEvent = new IVL_TS(new TS("20110101"), new TS("20120105"));')
+    @context.eval('nullEndEvent.high.date = null;')
+    @context.eval('var events4 = [{"asIVL_TS": function() {return nullEndEvent;}}]')
     @context.eval('var bound1 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120105"), new TS("20120105"));}}]')
     @context.eval('var bound2 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120107"), new TS("20120107"));}}]')
     @context.eval('var bound3 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120103"), new TS("20120107"));}}]')
@@ -430,6 +433,7 @@ class LibraryFunctionTest < Test::Unit::TestCase
     assert_equal 0, @context.eval('OVERLAP(events2, XPRODUCT(bound6))').count
     assert_equal 1, @context.eval('OVERLAP(events2, XPRODUCT(bound1))').count
     assert_equal 0, @context.eval('OVERLAP(events2, XPRODUCT(bound2))').count
+    assert_equal 1, @context.eval('OVERLAP(events4, bound1)').count
     
     # SCW
     assert_equal 1, @context.eval('SCW(events1, bound1)').count

--- a/test/unit/library_function_test.rb
+++ b/test/unit/library_function_test.rb
@@ -364,6 +364,7 @@ class LibraryFunctionTest < Test::Unit::TestCase
     @context.eval('var nullEndEvent = new IVL_TS(new TS("20110101"), new TS("20120105"));')
     @context.eval('nullEndEvent.high.date = null;')
     @context.eval('var events4 = [{"asIVL_TS": function() {return nullEndEvent;}}]')
+    @context.eval('var events5 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20140101"), new TS("20140201"));}}]')
     @context.eval('var bound1 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120105"), new TS("20120105"));}}]')
     @context.eval('var bound2 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120107"), new TS("20120107"));}}]')
     @context.eval('var bound3 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120103"), new TS("20120107"));}}]')
@@ -371,8 +372,11 @@ class LibraryFunctionTest < Test::Unit::TestCase
     @context.eval('var bound5 = {"asIVL_TS": function() {return new IVL_TS(new TS("20120106"), new TS("20120107"));}}')
     @context.eval('var nullStartBound = new IVL_TS(new TS("20120105"), new TS("20120105"));')
     @context.eval('nullStartBound.low.date = null;')
+    @context.eval('var nullEndBound = new IVL_TS(new TS("20140601"), new TS("20140601"));')
+    @context.eval('nullEndBound.high.date = null;')
     @context.eval('var bound6 = {"asIVL_TS": function() {return nullStartBound;}}')
     @context.eval('var bound7 = [{"asIVL_TS": function() {return new IVL_TS(new TS("20120105193030"), new TS("20120105193030"));}}]')
+    @context.eval('var bound8 = {"asIVL_TS": function() {return nullEndBound;}}')
     @context.eval('var range1 = new IVL_PQ(null, new PQ(1, "d"))')
     @context.eval('var range2 = new IVL_PQ(new PQ(1, "d"), null)')
     @context.eval('var range3 = new IVL_PQ(new PQ(0, "d"), null)')
@@ -433,7 +437,9 @@ class LibraryFunctionTest < Test::Unit::TestCase
     assert_equal 0, @context.eval('OVERLAP(events2, XPRODUCT(bound6))').count
     assert_equal 1, @context.eval('OVERLAP(events2, XPRODUCT(bound1))').count
     assert_equal 0, @context.eval('OVERLAP(events2, XPRODUCT(bound2))').count
+    ## Overlap with null endins
     assert_equal 1, @context.eval('OVERLAP(events4, bound1)').count
+    assert_equal 0, @context.eval('OVERLAP(events5, bound8)').count
     
     # SCW
     assert_equal 1, @context.eval('SCW(events1, bound1)').count

--- a/test/unit/library_function_test.rb
+++ b/test/unit/library_function_test.rb
@@ -437,7 +437,7 @@ class LibraryFunctionTest < Test::Unit::TestCase
     assert_equal 0, @context.eval('OVERLAP(events2, XPRODUCT(bound6))').count
     assert_equal 1, @context.eval('OVERLAP(events2, XPRODUCT(bound1))').count
     assert_equal 0, @context.eval('OVERLAP(events2, XPRODUCT(bound2))').count
-    ## Overlap with null endins
+    ## Overlap with null ending
     assert_equal 1, @context.eval('OVERLAP(events4, bound1)').count
     assert_equal 0, @context.eval('OVERLAP(events5, bound8)').count
     


### PR DESCRIPTION
## Story

https://www.pivotaltracker.com/s/projects/912050/stories/77112746
## Notes

If both object and other have non-null end dates, behavior is as previously defined. Otherwise, only look for a start before start. 
